### PR TITLE
Delete cron job if daily_auto_commits is disabled

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -75,5 +75,5 @@ template '/etc/cron.daily/etckeeper' do
   source 'etckeeper.erb'
   mode '0755'
   owner 'root'
-  only_if { node['etckeeper']['daily_auto_commits'] }
+  action node['etckeeper']['daily_auto_commits'] ? :create : :delete
 end


### PR DESCRIPTION
When `node['etckeeper']['daily_auto_commits']` is set to false,
the cron job definition is not deleted. This makes it impossible
(with the means of this cookbook) to really disable this feature
for already provisioned nodes.

Fix this, by specifying the appropriate action.