### PR TITLE
Update the cookbook to be compliant with the latest version of chef

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,13 +1,12 @@
-#chef_api :config
-#chef_api "https://chef.typo3.org/clients/", node_name: "pniederlag", client_key: "/srv/fileserver/projects/t3-team-server/certificates/client.pem"
+# chef_api :config
+# chef_api "https://chef.typo3.org/clients/", node_name: "pniederlag", client_key: "/srv/fileserver/projects/t3-team-server/certificates/client.pem"
 
+# cookbook "ssl_certificates", github: "TYPO3-cookbooks/ssl_certificates"
+# cookbook "redmine", github: "TYPO3-cookbooks/redmine", branch: "feature/berksonwheezy"
+cookbook 'chef-client'
+cookbook 'chef_handler'
+# cookbook "chef-solo-search", github: "edelight/chef-solo-search"
+# cookbook "git"
 
-#cookbook "ssl_certificates", github: "TYPO3-cookbooks/ssl_certificates"
-#cookbook "redmine", github: "TYPO3-cookbooks/redmine", branch: "feature/berksonwheezy"
-cookbook "chef-client"
-cookbook "chef_handler"
-#cookbook "chef-solo-search", github: "edelight/chef-solo-search"
-#cookbook "git"
-
-source "https://supermarket.getchef.com"
+source 'https://supermarket.chef.io'
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 3.1.5'
+gem 'berkshelf'
 
 group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
-  gem 'serverspec', '~> 2.1.0'
+  gem 'serverspec'
 end
 
 group :test do
   gem 'rake'
-  gem 'chefspec',   '~> 4.0.2'
-  gem 'rubocop',    '~> 0.26.1'
-  gem 'foodcritic', '~> 4.0'
+  gem 'chefspec'
+  gem 'rubocop'
+  gem 'cookstyle'
 end
 
 group :openstack do

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,13 @@
-# encoding: utf-8
-
 require 'rubocop/rake_task'
 require 'rspec/core/rake_task'
-require 'foodcritic'
+require 'cookstyle'
 
 RuboCop::RakeTask.new(:rubocop)
 
 RSpec::Core::RakeTask.new(:rspec)
 
-FoodCritic::Rake::LintTask.new do |t|
-  t.options = { fail_tags: ['any'] }
+RuboCop::RakeTask.new do |task|
+  task.options << '--display-cop-names'
 end
 
-task default: [:rubocop, :foodcritic, :rspec]
+task default: [:rubocop, :cookstyle, :rspec]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 default['etckeeper']['dir'] = '/etc/etckeeper'
-default['etckeeper']['config'] = "#{node['etckeeper']['dir']}/etckeeper.conf"
+default['etckeeper']['config'] = ::File.join(node['etckeeper']['dir'], 'etckeeper.conf')
 default['etckeeper']['vcs'] = 'git'
 default['etckeeper']['daily_auto_commits'] = true
 default['etckeeper']['special_file_warning'] = true

--- a/recipes/commit.rb
+++ b/recipes/commit.rb
@@ -1,9 +1,8 @@
-# encoding: UTF-8
 #
-# Cookbook Name:: etckeeper
+# Cookbook:: etckeeper
 # Recipe:: commit
 #
-# Copyright 2012-2013, Steffen Gebert / TYPO3 Association
+# Copyright:: 2012-2013, Steffen Gebert / TYPO3 Association
 #                      Peter Niederlag / TYPO3 Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'chef_handler::default'
-
 # clean up after old etckeeper recipe (<1.0.3)
 file '/etc/chef/client.d/etckeeper-handler.rb' do
   action :delete
@@ -34,11 +31,11 @@ end
 chef_handler 'Etckeeper::CommitHandler' do
   source "#{node['chef_handler']['handler_path']}/etckeeper_handler.rb"
   action :enable
-  supports report: true, exception: true
+  type report: true, exception: true
 end
 
 chef_handler 'Etckeeper::StartHandler' do
   source "#{node['chef_handler']['handler_path']}/etckeeper_handler.rb"
   action :enable
-  supports start: true
+  type start: true
 end

--- a/recipes/commit.rb
+++ b/recipes/commit.rb
@@ -23,19 +23,20 @@ file '/etc/chef/client.d/etckeeper-handler.rb' do
   action :delete
 end
 
-template "#{node['chef_handler']['handler_path']}/etckeeper_handler.rb" do
+file_handler = ::File.join(node['chef_handler']['handler_path'], 'etckeeper_handler.rb')
+template file_handler do
   source 'chef-client/etckeeper_handler.rb'
 end
 
 # We register ourself as a report handler, which runs at the end of chef run
 chef_handler 'Etckeeper::CommitHandler' do
-  source "#{node['chef_handler']['handler_path']}/etckeeper_handler.rb"
+  source file_handler
   action :enable
   type report: true, exception: true
 end
 
 chef_handler 'Etckeeper::StartHandler' do
-  source "#{node['chef_handler']['handler_path']}/etckeeper_handler.rb"
+  source file_handler
   action :enable
   type start: true
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -1,9 +1,8 @@
-# encoding: UTF-8
 #
-# Cookbook Name:: etckeeper
+# Cookbook:: etckeeper
 # Recipe:: config
 #
-# Copyright 2012-2013, Steffen Gebert / TYPO3 Association
+# Copyright:: 2012-2013, Steffen Gebert / TYPO3 Association
 #                      Peter Niederlag / TYPO3 Association
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,12 +22,12 @@ git_cmd = 'git --git-dir=/etc/.git'
 
 template node['etckeeper']['config'] do
   source 'etckeeper.conf.erb'
-  mode 0644
+  mode '644'
 end
 
 execute 'etckeeper init' do
   only_if { node['etckeeper']['vcs'] == 'git' }
-  not_if { File.exist?('/etc/.git/config') }
+  not_if { ::File.exist?('/etc/.git/config') }
   cwd '/etc'
 end
 
@@ -71,9 +70,11 @@ if node['etckeeper']['use_remote']
   end
 end
 
+# rubocop: disable Chef/Modernize/CronDFileOrTemplate
 template '/etc/cron.daily/etckeeper' do
   source 'etckeeper.erb'
   mode '0755'
   owner 'root'
   only_if { node['etckeeper']['daily_auto_commits'] }
 end
+# rubocop: enable Chef/Modernize/CronDFileOrTemplate

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,9 +1,8 @@
-# encoding: UTF-8
 #
-# Cookbook Name:: etckeeper
+# Cookbook:: etckeeper
 # Recipe:: default
 #
-# Copyright 2013, Alexander Saharchuk.
+# Copyright:: 2013, Alexander Saharchuk.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/recipes/commit_spec.rb
+++ b/spec/recipes/commit_spec.rb
@@ -1,9 +1,6 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 describe 'etckeeper::commit' do
-
   cached(:chef_run) do
     ChefSpec::Runner.new.converge(described_recipe)
   end

--- a/spec/recipes/config_spec.rb
+++ b/spec/recipes/config_spec.rb
@@ -9,31 +9,23 @@ describe 'etckeeper::config' do
     ).and_return(true)
   end
 
-  cached(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
-  end
-
   it 'creates the etckeeper config file' do
-    expect(chef_run).to render_file('/etc/etckeeper/etckeeper.conf')
+    is_expected.to render_file('/etc/etckeeper/etckeeper.conf')
   end
 
   it 'creates the etckeeper cron job by default' do
-    expect(chef_run).to create_template('/etc/cron.daily/etckeeper')
+    is_expected.to create_template('/etc/cron.daily/etckeeper')
       .with(owner: 'root')
       .with(mode: '0755')
-    expect(chef_run).to render_file('/etc/cron.daily/etckeeper')
+    is_expected.to render_file('/etc/cron.daily/etckeeper')
       .with_content(/etckeeper commit "daily autocommit"/)
   end
 
   context 'with attribute daily_auto_commits set to false' do
-    cached(:chef_run) do
-      ChefSpec::Runner.new do |node|
-        node.set['etckeeper']['daily_auto_commits'] = false
-      end.converge(described_recipe)
-    end
+    default_attributes['etckeeper']['daily_auto_commits'] = false
 
     it 'does not install the etckeeper cron job' do
-      expect(chef_run).not_to render_file('/etc/cron.daily/etckeeper')
+      is_expected.not_to render_file('/etc/cron.daily/etckeeper')
     end
   end
 
@@ -49,7 +41,7 @@ describe 'etckeeper::config' do
     cached(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
 
     it 'runs "etckeeper init"' do
-      expect(chef_run).to run_execute('etckeeper init')
+      is_expected.to run_execute('etckeeper init')
     end
   end
 
@@ -65,11 +57,12 @@ describe 'etckeeper::config' do
     cached(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
 
     it 'does not run "etckeeper init" again' do
-      expect(chef_run).not_to run_execute('etckeeper init')
+      is_expected.not_to run_execute('etckeeper init')
     end
   end
 
   context 'with attribute use_remote' do
+    default_attributes['etckeeper']['use_remote'] = true
     before do
       stub_command("#{git_cmd} config --get remote.origin.url")
         .and_return(false)
@@ -77,29 +70,23 @@ describe 'etckeeper::config' do
         .and_return(false)
     end
 
-    cached(:chef_run) do
-      ChefSpec::Runner.new do |node|
-        node.set['etckeeper']['use_remote'] = true
-      end.converge(described_recipe)
-    end
-
     it 'creates directory /root/.ssh' do
-      expect(chef_run).to create_directory('/root/.ssh')
+      is_expected.to create_directory('/root/.ssh')
         .with(owner: 'root')
         .with(group: 'root')
         .with(mode: '0700')
     end
 
     it 'creates the etckeeper ssh key' do
-      expect(chef_run).to create_cookbook_file_if_missing(
+      is_expected.to create_cookbook_file_if_missing(
         '/root/.ssh/etckeeper_key'
       ).with(mode: '0600')
     end
 
     it 'creates /root/.ssh/config' do
-      expect(chef_run).to create_template('/root/.ssh/config')
+      is_expected.to create_template('/root/.ssh/config')
         .with(mode: '0600')
-      expect(chef_run).to render_file('/root/.ssh/config')
+      is_expected.to render_file('/root/.ssh/config')
         .with_content(/^Host #{chef_run.node['etckeeper']['git_host']}$/)
         .with_content(/^\s+user\s+git$/)
         .with_content(/^\s+Port\s+#{chef_run.node['etckeeper']['git_port']}$/)
@@ -108,54 +95,44 @@ describe 'etckeeper::config' do
     end
 
     context 'without email address in git config' do
+      default_attributes['etckeeper']['git_email'] = 'x@example.com'
       before do
         stub_command(
           "#{git_cmd} config --get user.email | fgrep -q 'x@example.com'"
         ).and_return(false)
       end
 
-      cached(:chef_run) do
-        ChefSpec::Runner.new do |node|
-          node.set['etckeeper']['git_email'] = 'x@example.com'
-        end.converge(described_recipe)
-      end
-
       it 'adds the email to git config' do
-        expect(chef_run).to run_execute('etckeeper_set_git_email')
+        is_expected.to run_execute('etckeeper_set_git_email')
           .with(command: "#{git_cmd} config user.email 'x@example.com'")
       end
     end
 
     context 'with existing user info in git config' do
+      default_attributes['etckeeper']['git_email'] = 'x@example.com'
       before do
         stub_command(
           "#{git_cmd} config --get user.email | fgrep -q 'x@example.com'"
         ).and_return(true)
       end
 
-      cached(:chef_run) do
-        ChefSpec::Runner.new do |node|
-          node.set['etckeeper']['git_email'] = 'x@example.com'
-        end.converge(described_recipe)
-      end
-
       it 'does not set the email again' do
-        expect(chef_run).not_to run_execute('etckeeper_set_git_email')
+        is_expected.not_to run_execute('etckeeper_set_git_email')
       end
-
     end
 
     context 'without set git remote' do
       it 'adds the configured origin' do
         host = chef_run.node['etckeeper']['git_host']
         repo = chef_run.node['etckeeper']['git_repo']
-        expect(chef_run).to run_execute(
+        is_expected.to run_execute(
           "#{git_cmd} remote add origin #{host}:#{repo}"
         )
       end
     end
 
     context 'with set git remote' do
+      default_attributes['etckeeper']['use_remote'] = true
       before do
         stub_command("#{git_cmd} config --get remote.origin.url")
           .and_return('something')
@@ -163,22 +140,17 @@ describe 'etckeeper::config' do
           .and_return('something')
       end
 
-      cached(:chef_run) do
-        ChefSpec::Runner.new do |node|
-          node.set['etckeeper']['use_remote'] = true
-        end.converge(described_recipe)
-      end
-
       it 'does not change the configured origin' do
         host = chef_run.node['etckeeper']['git_host']
         repo = chef_run.node['etckeeper']['git_repo']
-        expect(chef_run).not_to run_execute(
+        is_expected.not_to run_execute(
           "#{git_cmd} remote add origin #{host}:#{repo}"
         )
       end
     end
 
     context 'without set remote git branch' do
+      default_attributes['etckeeper']['use_remote'] = true
       before do
         stub_command("#{git_cmd} config --get remote.origin.url")
           .and_return('something')
@@ -186,21 +158,16 @@ describe 'etckeeper::config' do
           .and_return(false)
       end
 
-      cached(:chef_run) do
-        ChefSpec::Runner.new do |node|
-          node.set['etckeeper']['use_remote'] = true
-        end.converge(described_recipe)
-      end
-
       it 'sets the branch' do
         branch = chef_run.node['etckeeper']['git_branch']
-        expect(chef_run).to run_execute(
+        is_expected.to run_execute(
           "#{git_cmd} push --set-upstream origin #{branch}"
         )
       end
     end
 
     context 'with existing remote git branch' do
+      default_attributes['etckeeper']['use_remote'] = true
       before do
         stub_command("#{git_cmd} config --get remote.origin.url")
           .and_return('something')
@@ -208,15 +175,9 @@ describe 'etckeeper::config' do
           .and_return('something')
       end
 
-      cached(:chef_run) do
-        ChefSpec::Runner.new do |node|
-          node.set['etckeeper']['use_remote'] = true
-        end.converge(described_recipe)
-      end
-
       it 'does not set the branch' do
         branch = chef_run.node['etckeeper']['git_branch']
-        expect(chef_run).not_to run_execute(
+        is_expected.not_to run_execute(
           "#{git_cmd} push --set-upstream origin #{branch}"
         )
       end

--- a/spec/recipes/config_spec.rb
+++ b/spec/recipes/config_spec.rb
@@ -1,9 +1,6 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 describe 'etckeeper::config' do
-
   git_cmd = 'git --git-dir=/etc/.git'
 
   before do

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,9 +1,6 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 describe 'etckeeper::default' do
-
   before do
     git_cmd = 'git --git-dir=/etc/.git'
     stub_command(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,9 @@
 require 'chefspec'
-require 'chefspec/server'
 require 'chefspec/berkshelf'
 require 'chefspec/cacher'
 
 RSpec.configure do |config|
   config.platform = 'ubuntu'
-  config.version = '14.04'
+  config.version = '20.04'
   config.log_level = :error
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'chefspec'
 require 'chefspec/server'
 require 'chefspec/berkshelf'
@@ -10,5 +8,3 @@ RSpec.configure do |config|
   config.version = '14.04'
   config.log_level = :error
 end
-
-at_exit { ChefSpec::Coverage.report! }

--- a/templates/default/chef-client/etckeeper_handler.rb
+++ b/templates/default/chef-client/etckeeper_handler.rb
@@ -13,7 +13,7 @@ module Etckeeper
           Chef::Log.error(
             'Found changes to /etc: ' + Etckeeper::Helpers.git_diff
           )
-          Chef::Application.fatal! '/etc is NOT clean. Stopping chef-run'
+          raise('/etc is NOT clean. Stopping chef-run')
         else
           Chef::Log.debug '/etc seems clean, continuing'
         end
@@ -36,7 +36,7 @@ module Etckeeper
       unless Etckeeper::Helpers.unclean?
         Chef::Log.debug(
          'Etckeeper::CommitHandler: /etc was not touched by this chef-run'
-        )
+       )
         return
       end
 

--- a/test/integration/default/serverspec/commit_spec.rb
+++ b/test/integration/default/serverspec/commit_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe 'etckeeper::commit' do
@@ -18,5 +16,4 @@ describe 'etckeeper::commit' do
   describe file('/etc/chef/client.d/etckeeper-handler.rb') do
     it { should_not be_file }
   end
-
 end

--- a/test/integration/default/serverspec/config_spec.rb
+++ b/test/integration/default/serverspec/config_spec.rb
@@ -1,9 +1,6 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 describe 'etckeeper::config' do
-
   describe file('/etc/etckeeper/etckeeper.conf') do
     it { should be_file }
     it { should be_owned_by 'root' }
@@ -38,5 +35,4 @@ describe 'etckeeper::config' do
   describe command('git --git-dir=/etc/.git config --get user.email') do
     its(:stdout) { should eq "root@etckeeper.example.com\n" }
   end
-
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe 'etckeeper' do

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'serverspec'
 # Set backend type
 set :backend, :exec


### PR DESCRIPTION
Hello,

STATE:
This cookbook has not been updated since 2018 and most of the tests are not compliant with the latest version of Chefspec and chef

So I would like to update it to the latest version of the gems used inside it.

Kind regards,
JM