### PR TITLE
feat(ssh): Add the possibility to set a cookbook for ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 =====
 * Add to run_list `recipe['etckeeper']` for local using etckeeper
 * Set `['use_remote']` to `true` for daily auto push to remote:
- * Make ssh key and copy to `./files/default/etckeeper_key`
+ * Make ssh key and copy to `./files/default/etckeeper_key` or create a wrapper cookbook with the ssh key you want to deploy then set following attribute: `node['etckeeper']['ssh']['key']['cookbook']`
  * Set your `git_host` and `git_port` if your need
  * Set at atribute for git repo. For example github repo `default['etckeeper']['git_repo'] = "myuser/myrepo.git"`
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@ default['etckeeper']['daily_auto_commits'] = true
 default['etckeeper']['special_file_warning'] = true
 default['etckeeper']['commit_before_install'] = true
 default['etckeeper']['use_remote'] = false
+default['etckeeper']['ssh']['key']['cookbook'] = 'etckeeper'
 default['etckeeper']['git_host'] = 'github.com'
 default['etckeeper']['git_port'] = 22
 default['etckeeper']['git_repo'] = 'etckeeper'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -49,6 +49,7 @@ if node['etckeeper']['use_remote']
 
   cookbook_file '/root/.ssh/etckeeper_key' do
     source 'etckeeper_key'
+    cookbook node['etckeeper']['ssh']['key']['cookbook']
     mode '0600'
     action :create_if_missing
   end


### PR DESCRIPTION
STATE:
There is no current way to use a wrap cookbook to set the ssh key for
the remote host.

FIX:
Add the cookbook attribute on the resource that deploys the ssh key, so
now, the user is able to override this value with a wrapper cookbook.

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>