### PR TITLE
test(travis): Update ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.5.9
+  - 2.6.10
+  - 3.0.0
 language: ruby
 bundler_args: --without integration

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RuboCop::RakeTask.new(:rubocop)
 
 RSpec::Core::RakeTask.new(:rspec)
 
-RuboCop::RakeTask.new do |task|
+RuboCop::RakeTask.new(:cookstyle) do |task|
   task.options << '--display-cop-names'
 end
 

--- a/spec/recipes/config_spec.rb
+++ b/spec/recipes/config_spec.rb
@@ -13,9 +13,6 @@ describe 'etckeeper::config' do
     is_expected.to render_file('/etc/etckeeper/etckeeper.conf')
   end
 
-  context 'with attribute daily_auto_commits set to false' do
-    default_attributes['etckeeper']['daily_auto_commits'] = false
-
   context 'without existing git repository' do
     before do
       allow(File).to receive(:exist?)


### PR DESCRIPTION
STATE:
By updating all the gems, the ruby version has to be also updated,
otherwise the tests are failing because travis is not able to find
compatible gems (Ref:
https://app.travis-ci.com/github/pioneerit/etckeeper-cookbook/jobs/568317224)

FIX:
Bump the ruby version comptible from chef 15

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>