### PR TITLE
fix(handler): Error when running '--why-run'

### DIFF
--- a/recipes/commit.rb
+++ b/recipes/commit.rb
@@ -39,4 +39,5 @@ chef_handler 'Etckeeper::StartHandler' do
   source file_handler
   action :enable
   type start: true
+  only_if { ::File.exits?(file_handler) }
 end


### PR DESCRIPTION
STATE:
When running chef in --why-run the file handler is not deployed, so the
chef-client displays the following:
>>[2022-04-28T19:15:19+02:00] FATAL: Stacktrace dumped to /XXXXXX
>>[2022-04-28T19:15:19+02:00] FATAL: ---------------------------------------------------------------------------------------
>>[2022-04-28T19:15:19+02:00] FATAL: PLEASE PROVIDE THE CONTENTS OF THE stacktrace.out FILE (above) IF YOU FILE A BUG REPORT
>>[2022-04-28T19:15:19+02:00] FATAL: ---------------------------------------------------------------------------------------
>>[2022-04-28T19:15:19+02:00] FATAL: LoadError: cannot load such file -- /etc/chef/handlers/etckeeper_handler.rb

PROPOSED SOLUTION:
Only activate the handler if the file is present

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>