### PR TITLE
test(kitechn-dokken): Add 'kitchen-dokken'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :test do
   gem 'chefspec'
   gem 'rubocop'
   gem 'cookstyle'
+  gem 'kitchen-dokken'
+  gem 'kitchen-inspec'
 end
 
 group :openstack do

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,0 +1,63 @@
+---
+driver:
+  name: dokken
+  privileged: true  # because Docker and SystemD
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
+
+platforms:
+  - name: debian-9
+    driver:
+      image: dokken/debian-9
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: centos-8
+    driver:
+      image: dokken/centos-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: fedora-latest
+    driver:
+      image: dokken/fedora-latest
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: ubuntu-16.04
+    driver:
+      image: dokken/ubuntu-16.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update


### PR DESCRIPTION
STATE:
Vagrant is great but 'kitchen-dokken' could be even faster.

PROPOSE SOLUTION:
Add the 'kitchen-dokken' file which could overloaded the default kitchen
framework:
`KITCHEN_LOCAL_YAML="kitchen.dokken.yml" kitchen conv`

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>