### PR TITLE
Update the start handler & remove package installation failing chef run

### DIFF
--- a/files/0001-feat-etckeeper-Add-unstash-for-etckeeper.patch
+++ b/files/0001-feat-etckeeper-Add-unstash-for-etckeeper.patch
@@ -1,0 +1,37 @@
+From 9b6384516f5fcf57840dd4441dd4edcebd82d64c Mon Sep 17 00:00:00 2001
+From: Jeremy MAURO <jeremy.mauro@gmail.com>
+Date: Fri, 3 Jun 2022 18:17:00 +0200
+Subject: [PATCH] feat(etckeeper): Add unstash for etckeeper
+
+STATE:
+When adding new package, 'etckeeper' can only commit '/etc' as a whole
+but when adding new package we just want to commit the files created by
+the package installation.
+
+PROPOSED SOLUTION:
+A hook has been created to stash everything before installing new
+packages, so we have to unstage everything after.
+
+Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>
+---
+ etckeeper/post-install.d/99unstash | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100755 etckeeper/post-install.d/99unstash
+
+diff --git a/etckeeper/post-install.d/99unstash b/etckeeper/post-install.d/99unstash
+new file mode 100755
+index 0000000..203cdca
+--- /dev/null
++++ b/etckeeper/post-install.d/99unstash
+@@ -0,0 +1,8 @@
++#!/bin/sh
++set -e
++
++if [ ! -z "${IN_CHEF}" ]; then
++        if ! etckeeper vcs stash pop --quiet; then
++                echo "warning: etckeeper failed to unstash changes in /etc using $VCS" >&2
++        fi
++fi
+-- 
+2.35.1
+

--- a/files/0001-feat-etckeeper-Create-a-hook-to-stash-changes-before.patch
+++ b/files/0001-feat-etckeeper-Create-a-hook-to-stash-changes-before.patch
@@ -1,0 +1,45 @@
+From 1e132bbbf237f2adec728bb2a640ae16be340782 Mon Sep 17 00:00:00 2001
+From: Jeremy MAURO <jeremy.mauro@gmail.com>
+Date: Fri, 3 Jun 2022 16:00:43 +0200
+Subject: [PATCH] feat(etckeeper): Create a hook to stash changes before
+ packages hooks
+
+STATE:
+During a chef-run configuration files as well as package could be added.
+When doing so, "etckeeper" doesn't allow to do both operation during the
+same run.
+
+PROPOSED SOLUTION:
+Create a hook in the package sanity check to stash all modification
+prior to the package installation, so the 'unclean' should pass.
+
+Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>
+---
+ etckeeper/pre-install.d/50uncommitted-changes | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/etckeeper/pre-install.d/50uncommitted-changes b/etckeeper/pre-install.d/50uncommitted-changes
+index 969d341..b418c4e 100755
+--- a/etckeeper/pre-install.d/50uncommitted-changes
++++ b/etckeeper/pre-install.d/50uncommitted-changes
+@@ -1,6 +1,17 @@
+ #!/bin/sh
+ set -e
+ 
++if [ ! -z "${IN_CHEF}" ]; then
++	if [ "$VCS" = git ] && [ -d .git ]; then
++		if ! etckeeper vcs add -v --all; then
++			echo "warning: etckeeper vcs add --all" >&2
++		fi
++		if ! etckeeper vcs stash push --quiet --message "uncommitted changes prior to ${HIGHLEVEL_PACKAGE_MANAGER}"; then
++			echo "warning: etckeeper failed to stash changes before installing packages with ${VCS}" >&2
++		fi
++	fi
++fi
++
+ if etckeeper unclean; then
+ 	if [ "$AVOID_COMMIT_BEFORE_INSTALL" = 1 ]; then
+ 		echo "" >&2
+-- 
+2.35.1
+

--- a/libraries/event_handler.rb
+++ b/libraries/event_handler.rb
@@ -1,0 +1,54 @@
+#
+# Chef Infra Documentation
+# https://docs.chef.io/libraries/
+#
+
+#
+# This module name was auto-generated from the cookbook name. This name is a
+# single word that starts with a capital letter and then continues to use
+# camel-casing throughout the remainder of the name.
+#
+
+module Etckeeper
+  class Handler
+    def check_etckeeper_before_run
+      ::Chef::Log.info 'Etckeeper::Sanity checks => inspecting /etc'
+      if Etckeeper::Helpers.git_repo?
+        if Etckeeper::Helpers.unclean?
+          ::Chef::Log.error(
+            'Found changes to /etc: ' + "\n>> #{Etckeeper::Helpers.git_diff}"
+          )
+          raise('/etc is NOT clean. Stopping chef-run')
+        else
+          ::Chef::Log.debug '/etc seems clean, continuing'
+        end
+      else
+        ::Chef::Log.warn '/etc seems to be not a Git repositry'
+      end
+    end
+  end
+
+  class Helpers
+    extend Chef::Mixin::ShellOut
+
+    def self.git_repo?
+      ::File.directory?('/etc/.git')
+    end
+
+    def self.unclean?
+      so = shell_out('etckeeper unclean')
+      so.exitstatus == 0
+    end
+
+    def self.git_diff
+      so = shell_out('cd /etc; git status --porcelain')
+      so.stdout.split("\n").join("\n>> ")
+    end
+  end
+end
+
+Chef.event_handler do
+  on :library_load_complete do
+    Etckeeper::Handler.new.check_etckeeper_before_run
+  end
+end

--- a/libraries/event_handler.rb
+++ b/libraries/event_handler.rb
@@ -50,5 +50,6 @@ end
 Chef.event_handler do
   on :library_load_complete do
     Etckeeper::Handler.new.check_etckeeper_before_run
+    ENV['IN_CHEF'] = "1"
   end
 end

--- a/recipes/commit.rb
+++ b/recipes/commit.rb
@@ -23,7 +23,9 @@ file '/etc/chef/client.d/etckeeper-handler.rb' do
   action :delete
 end
 
-directory node['etckeeper']['handler_path']
+directory node['etckeeper']['handler_path'] do
+  recursive true
+end
 
 file_handler = ::File.join(node['etckeeper']['handler_path'], 'etckeeper_handler.rb')
 
@@ -36,10 +38,4 @@ chef_handler 'Etckeeper::CommitHandler' do
   source file_handler
   action :enable
   type report: true, exception: true
-end
-
-chef_handler 'Etckeeper::StartHandler' do
-  source file_handler
-  action :enable
-  type start: true
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,40 @@ directory '/etc/.bzr' do
   recursive true
 end
 
+patches_list = %w{
+  0001-feat-etckeeper-Add-unstash-for-etckeeper.patch
+  0001-feat-etckeeper-Create-a-hook-to-stash-changes-before.patch
+}
+patches_list.each do |patch_file|
+  full_path = ::File.join(::Chef::Config.file_cache_path, patch_file)
+  cookbook_file full_path do
+    source patch_file
+    owner 'root'
+    group 'root'
+    only_if { node['etckeeper']['config_file']['VCS'] == 'git' }
+  end
+
+  execute "etckeeper vcs am #{full_path}" do
+    cwd '/etc'
+    only_if "etckeeper vcs apply #{full_path} --check"
+    only_if { node['etckeeper']['config_file']['VCS'] == 'git' }
+    notifies :run, 'execute[etckeeper pre-commit]', :immediate
+  end
+
+  execute "Commit updated metastore(#{patch_file})" do
+    command "git commit -m 'Updating metastore after applying #{patch_file}'"
+    cwd '/etc'
+    only_if { node['etckeeper']['config_file']['VCS'] == 'git' }
+    not_if 'git diff --staged --exit-code .etckeeper'
+    action :nothing
+  end
+end
+
+execute 'etckeeper pre-commit' do
+  action :nothing
+  patches_list.each do |patch_file|
+    notifies :run, "execute[Commit updated metastore(#{patch_file})]", :immediate
+  end
+end
+
 include_recipe 'etckeeper::config'

--- a/templates/default/chef-client/etckeeper_handler.rb
+++ b/templates/default/chef-client/etckeeper_handler.rb
@@ -3,34 +3,6 @@ require 'chef/log'
 require 'chef/mixin/shell_out'
 
 module Etckeeper
-  class StartHandler < ::Chef::Handler
-    def report
-      Chef::Log.info 'Etckeeper::StartHandler inspecting /etc'
-
-      if Etckeeper::Helpers.git_repo?
-        if Etckeeper::Helpers.unclean?
-
-          Chef::Log.error(
-            'Found changes to /etc: ' + Etckeeper::Helpers.git_diff
-          )
-          raise('/etc is NOT clean. Stopping chef-run')
-        else
-          Chef::Log.debug '/etc seems clean, continuing'
-        end
-
-      else
-        Chef::Log.warn '/etc seems to be not a Git repositry'
-      end
-    end
-
-    # we are overriding this method in order to be able to fail the chef run
-    # (all the handlers are called in a way that all their exceptions are
-    # caught)
-    def run_report_safely(run_status)
-      run_report_unsafe(run_status)
-    end
-  end
-
   class CommitHandler < ::Chef::Handler
     def report
       unless Etckeeper::Helpers.unclean?
@@ -61,24 +33,6 @@ module Etckeeper
       end
 
       Chef::Log.debug `etckeeper commit "#{message.join("\n")}"`
-    end
-  end
-
-  class Helpers
-    extend Chef::Mixin::ShellOut
-
-    def self.git_repo?
-      File.directory?('/etc/.git')
-    end
-
-    def self.unclean?
-      so = shell_out('etckeeper unclean')
-      so.exitstatus == 0
-    end
-
-    def self.git_diff
-      so = shell_out('cd /etc; git diff')
-      so.stdout
     end
   end
 end


### PR DESCRIPTION
Hello,

I know this pull request is a bit long because I am trying to solve two issues:
- the start handler not working on recent chef-client
- making chef run fails uniquely when it must, and not artificially.

Look at the commit message and tell me if there are clear enough.

Kind regards,
JM